### PR TITLE
Create basic portfolio pages

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,9 @@
+export default function ContactPage() {
+  return (
+    <section className="py-8 md:py-10">
+      <h1 className="text-3xl font-bold mb-4">Contact Me</h1>
+      <p className="text-lg mb-2">Feel free to reach out via email:</p>
+      <a href="mailto:example@example.com" className="text-primary underline">example@example.com</a>
+    </section>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,11 @@
 export default function Home() {
-	return (
-		<section className="flex flex-col items-center justify-center gap-4 py-8 md:py-10">
-			
-		</section>
-	);
+  return (
+    <section className="flex flex-col items-center justify-center gap-4 py-8 md:py-10">
+      <h1 className="text-4xl font-bold">Welcome to my portfolio</h1>
+      <p className="text-lg text-center max-w-xl">
+        I'm building this site with Next.js. Check out my projects and feel free to get in touch!
+      </p>
+    </section>
+  );
 }
+

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,0 +1,13 @@
+export default function ProjectsPage() {
+  return (
+    <section className="py-8 md:py-10">
+      <h1 className="text-3xl font-bold mb-4">Projects</h1>
+      <p className="text-lg">Here are a few of my favorite side projects.</p>
+      <ul className="list-disc list-inside mt-4 space-y-2">
+        <li>Sample Project One</li>
+        <li>Sample Project Two</li>
+        <li>Sample Project Three</li>
+      </ul>
+    </section>
+  );
+}

--- a/config/site.ts
+++ b/config/site.ts
@@ -3,62 +3,34 @@ export type SiteConfig = typeof siteConfig;
 export const siteConfig = {
 	name: "Next.js + NextUI",
 	description: "Make beautiful websites regardless of your design experience.",
-	navItems: [
-		{
-			label: "Home",
-			href: "/",
-		},
-    {
-      label: "Docs",
-      href: "/docs",
-    },
-    {
-      label: "Pricing",
-      href: "/pricing",
-    },
-    {
-      label: "Blog",
-      href: "/blog",
-    },
-    {
-      label: "About",
-      href: "/about",
-    }
-	],
-	navMenuItems: [
-		{
-			label: "Profile",
-			href: "/profile",
-		},
-		{
-			label: "Dashboard",
-			href: "/dashboard",
-		},
-		{
-			label: "Projects",
-			href: "/projects",
-		},
-		{
-			label: "Team",
-			href: "/team",
-		},
-		{
-			label: "Calendar",
-			href: "/calendar",
-		},
-		{
-			label: "Settings",
-			href: "/settings",
-		},
-		{
-			label: "Help & Feedback",
-			href: "/help-feedback",
-		},
-		{
-			label: "Logout",
-			href: "/logout",
-		},
-	],
+        navItems: [
+                {
+                        label: "Intro",
+                        href: "/",
+                },
+                {
+                        label: "Projects",
+                        href: "/projects",
+                },
+                {
+                        label: "Contact",
+                        href: "/contact",
+                },
+        ],
+        navMenuItems: [
+                {
+                        label: "Intro",
+                        href: "/",
+                },
+                {
+                        label: "Projects",
+                        href: "/projects",
+                },
+                {
+                        label: "Contact",
+                        href: "/contact",
+                },
+        ],
 	links: {
 		github: "https://github.com/nextui-org/nextui",
 		twitter: "https://twitter.com/getnextui",


### PR DESCRIPTION
## Summary
- add intro text on landing page
- add a projects page and contact page
- simplify site navigation links to Intro, Projects and Contact

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d76525b708322bf28cb6a34ee3071